### PR TITLE
Fix for dialog Finish buttons and removal of static lists from XMl processor

### DIFF
--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc0Types.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc0Types.java
@@ -45,7 +45,7 @@ import com.iawg.ecoa.systemmodel.types.SM_Variant_Record_Type;
  */
 public class XMLProc0Types {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc0Types.class);
-	private static List<ECOAFile> arrLstLibraryFile = new ArrayList<ECOAFile>();
+	private List<ECOAFile> arrLstLibraryFile = new ArrayList<ECOAFile>();
 
 	private void checkType(SystemModel systemModel, String currentNamespace, String typeName) {
 		boolean exists = false;

--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc1ServiceDefs.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc1ServiceDefs.java
@@ -36,7 +36,7 @@ import com.iawg.ecoa.systemmodel.servicedefinition.serviceoperation.SM_RRService
 public class XMLProc1ServiceDefs {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc1ServiceDefs.class);
 	private static final String SEP_PATTERN_21 = "Service ";
-	private static List<ECOAFile> serviceDefinitions = new ArrayList<ECOAFile>();
+	private List<ECOAFile> serviceDefinitions = new ArrayList<ECOAFile>();
 
 	private List<Data> getData(ServiceDefinition sd) {
 		List<Data> dataList = new ArrayList<Data>();

--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc2aCompDefs.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc2aCompDefs.java
@@ -34,7 +34,7 @@ import com.iawg.ecoa.systemmodel.componentdefinition.serviceinstance.SM_ServiceI
  */
 public class XMLProc2aCompDefs {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc2aCompDefs.class);
-	private static List<ECOAFile> componentDefinitions = new ArrayList<ECOAFile>();
+	private List<ECOAFile> componentDefinitions = new ArrayList<ECOAFile>();
 
 	private String getComponentNameFromFilename(Path name) {
 		String sa[] = name.getFileName().toString().split("/");

--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc4aCompImpl.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc4aCompImpl.java
@@ -106,7 +106,7 @@ import com.iawg.ecoa.systemmodel.servicedefinition.serviceoperation.SM_RRService
 public class XMLProc4aCompImpl {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc4aCompImpl.class);
 	private static final String SEP_PATTERN_41 = "moduleInstance";
-	private static List<ECOAFile> componentImplementations = new ArrayList<ECOAFile>();
+	private List<ECOAFile> componentImplementations = new ArrayList<ECOAFile>();
 	private SystemModel systemModel;
 	private Integer repoID = 1;
 

--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc4bBinDesc.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc4bBinDesc.java
@@ -26,7 +26,7 @@ import com.iawg.ecoa.systemmodel.componentimplementation.SM_ModuleImpl;
  */
 public class XMLProc4bBinDesc {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc4bBinDesc.class);
-	private static List<ECOAFile> binDescFiles = new ArrayList<ECOAFile>();
+	private List<ECOAFile> binDescFiles = new ArrayList<ECOAFile>();
 
 	public void parseFile(Path binDescFile) {
 		XMLFileProcessor pxfp = new XMLFileProcessor("ecoa-bin-desc-1.0.xsd", "com.iawg.ecoa.jaxbclasses.step4bBinDesc");

--- a/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc5cDeployment.java
+++ b/osets-eclipse-plugin/src/com/iawg/ecoa/xmlprocessor/XMLProc5cDeployment.java
@@ -39,7 +39,7 @@ import com.iawg.ecoa.systemmodel.deployment.logicalsystem.SM_LogicalComputingPla
 public class XMLProc5cDeployment {
 	private static final Logger LOGGER = LogManager.getLogger(XMLProc5cDeployment.class);
 	private static final String SEP_PATTERN_01 = " does not exist";
-	public static List<Deployment> deployments = new ArrayList<Deployment>();
+	public List<Deployment> deployments = new ArrayList<Deployment>();
 
 	public void parseFile(Path deploymentFile) {
 		XMLFileProcessor pxfp = new XMLFileProcessor("ecoa-deployment-1.0.xsd", "com.iawg.ecoa.jaxbclasses.step5cDeployment");

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/CompDefWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/CompDefWizard.java
@@ -192,7 +192,7 @@ public class CompDefWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 }

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/InitAssemblyWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/InitAssemblyWizard.java
@@ -169,7 +169,7 @@ public class InitAssemblyWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/IntLogicalSysWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/IntLogicalSysWizard.java
@@ -165,7 +165,7 @@ public class IntLogicalSysWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/ServicesWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/ServicesWizard.java
@@ -185,7 +185,7 @@ public class ServicesWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/TypesWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/TypesWizard.java
@@ -189,7 +189,7 @@ public class TypesWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override


### PR DESCRIPTION
This update fixes two issues:
1. The wizard dialogs for types, services, logical system, initial assembly and component definition had the 'Finish' button enabled by default. This allowed submission of the forms unlike the other multi-page wizard dialogs. Modification of the canFinish methods to check whether the page was complete resolves this issue.

2. The implementation of the XML processor is using 'static' lists in certain parts. What this means is that the plugin maintains the previous version in memory, even when you have changed the XML provided. This can be VERY confusing if you don't realise it is happening.
Removal of the 'static' from the lists in the XML processor files and regenerating the plugin fixes this. 
This resolves part of issue #9. 